### PR TITLE
remove blank line between results in output

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -163,7 +163,7 @@ func printList(items map[string]bool, toPath bool) {
 			res = convertToPath(res)
 		}
 
-		launchr.Term().Println(res)
+		launchr.Term().Print(res + "\n")
 	}
 }
 


### PR DESCRIPTION
This method will change the output to remove the blank lines between every result line. Here is an example:
```
plasmactl dependencies foundation/applications/roles/metrics
INFO  Selected source is .compose/build
INFO  Dependencies:
foundation/services/roles/metrics_prometheus_alert_machine

foundation/softwares/roles/prometheus

foundation/softwares/roles/prometheus_alert_machine

integration/libraries/roles/application
...
```

to 
```
plasmactl dependencies foundation/applications/roles/metrics
INFO  Selected source is .compose/build
INFO  Dependencies:
foundation/services/roles/metrics_prometheus_alert_machine
foundation/softwares/roles/prometheus
foundation/softwares/roles/prometheus_alert_machine
integration/libraries/roles/application
...
```
It allow to get a better experience for user that want to chain multiple commands between them.
Eg if I want to get the defaults values of a new component and all its dependencies I can do:
`for dep_path in $(plasmactl dependencies foundation/applications/roles/metrics); do cat $dep_path/defaults/main.yaml; done`